### PR TITLE
Fix dark/burned decode output for Qwen-Image (regression from ComfyUI #11405/#11406)

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -109,7 +109,16 @@ class VAEUtils_VAEDecodeTiled:
         
         if len(images.shape) == 5: #Combine batches
             images = images.reshape(-1, images.shape[-3], images.shape[-2], images.shape[-1])
-        
+
+        # Safety guard for ComfyUI PRs #11405 / #11406 regression:
+        # If process_output was not applied through the inherited VAE.decode() path the raw
+        # decoder output lands in [-1, 1].  Values below 0 are clamped to black by save/preview
+        # nodes, producing the dark/burned look.  Detect and correct here.
+        # This guard is safe on correctly-decoded images because they are always in [0, 1]
+        # so min >= 0 and the branch never fires.
+        if images.min() < -0.1:
+            images = torch.clamp((images.float() + 1.0) / 2.0, min=0.0, max=1.0)
+
         if upscale < 1:
             ch = images.shape[-1]
             if ch == 3:
@@ -119,8 +128,10 @@ class VAEUtils_VAEDecodeTiled:
                     upscale = round((ch // 3) ** 0.5)
                 else:
                     raise Exception("Couldn't determine upscale factor, try setting the value manually instead")
-        
-        images = F.pixel_shuffle(images.movedim(-1, 1), upscale_factor=int(upscale)).movedim(1, -1)
+
+        if upscale > 1:
+            images = F.pixel_shuffle(images.movedim(-1, 1), upscale_factor=int(upscale)).movedim(1, -1)
+
         return (images, )
 
 

--- a/src/sd.py
+++ b/src/sd.py
@@ -363,6 +363,47 @@ class CustomVAE(VAE):
         self.patcher = comfy.model_patcher.ModelPatcher(self.first_stage_model, load_device=self.device, offload_device=offload_device)
         logging.info("VAE load device: {}, offload device: {}, dtype: {}".format(self.device, offload_device, self.vae_dtype))
 
+    def decode(self, samples_in):
+        """
+        Override VAE.decode() to fix a regression introduced in ComfyUI PRs #11405 / #11406
+        (merged Dec 18 2025).  Those PRs changed the 3D untiled decode path inside
+        VAE.decode() so that it no longer routes through decode_tiled_3d for subclasses;
+        it now does inline channel allocation and trimming that breaks CustomVAE because it
+        only sees self.output_channels (= input_channels = 3) and ignores
+        self.real_output_channels (the actual decoder head output count, e.g. 12 for the
+        Wan 2x upscale VAE).  process_output was also no longer guaranteed to be applied
+        through that path.
+
+        For 2D VAEs (latent_dim != 3) we delegate to the parent as before.
+        For 3D VAEs (WanVAE family: Wan 2.1, Wan 2.2, Qwen-Image, Wan 2x upscale) we do
+        the model-loading bookkeeping ourselves, then call our own decode_tiled_3d which
+        already handles real_output_channels and process_output correctly.
+        """
+        if self.latent_dim != 3:
+            return super().decode(samples_in)
+
+        # Mirror the memory-management preamble from the parent's decode().
+        memory_used = self.memory_used_decode(samples_in.shape, self.vae_dtype)
+        model_management.load_models_gpu([self.patcher], memory_required=memory_used)
+
+        # decode_tiled_3d returns process_output(tiled_scale_multidim(...)) whose shape is
+        # [B, real_output_channels, T_out, H_out, W_out]  (5-D for multi-frame video)
+        # or [B, real_output_channels, H_out, W_out]       (4-D if tiled_scale_multidim
+        #                                                    squeezed the temporal dim)
+        images = self.decode_tiled_3d(samples_in)
+
+        # Normalise to [B*T, H, W, C] — same layout that the parent returns and that
+        # VAEUtils_VAEDecodeTiled.decode() expects (it has its own 5-D reshape guard too).
+        if images.ndim == 5:
+            B, C, T, H, W = images.shape
+            images = images.permute(0, 2, 3, 4, 1).reshape(B * T, H, W, C)
+        elif images.ndim == 4:
+            # Already [B, C, H, W] — just move channels to last dim.
+            images = images.movedim(1, -1)
+        # ndim == 3 or anything unexpected: leave as-is and let downstream handle it.
+
+        return images
+
     def decode_tiled_3d(self, samples, tile_t=999, tile_x=32, tile_y=32, overlap=(1, 8, 8)):
         decode_fn = lambda a: self.first_stage_model.decode(a.to(self.vae_dtype).to(self.device)).float()
         return self.process_output(


### PR DESCRIPTION
**Problem**

After ComfyUI PRs [#11405](https://github.com/Comfy-Org/ComfyUI/pull/11405) ("Support loading Wan/Qwen VAEs with different in/out channels") and [#11406](https://github.com/Comfy-Org/ComfyUI/pull/11406) ("Trim/pad channels in VAE code"), merged December 18 2025, decoding Qwen-Image latents through `VAE Decode (VAE Utils)` produces dark, burned-looking output. Wan video generation is unaffected. This was reported in issue #19.

The root cause: `CustomVAE` inherits `decode()` from ComfyUI's `VAE` base class without overriding it. Those PRs changed the 3D untiled decode path inside `VAE.decode()` to do inline channel allocation and trimming using `self.output_channels`, bypassing the existing `decode_tiled_3d()` override in `CustomVAE`. As a result, `process_output` (which maps raw decoder output from `[-1, 1]` to `[0, 1]`) was no longer reliably applied on the untiled path. Pixel values below zero got clamped to black by downstream save/preview nodes, producing the dark appearance.

Wan video was unaffected because it typically decodes with `tile=True`, which routes through `vae.decode_tiled()` → `decode_tiled_3d()` directly, bypassing the broken `VAE.decode()` path entirely. The Wan 2x upscale VAE was also unaffected for the same reason. Qwen-Image at standard resolution uses `tile=False`, so it hit the broken path.

**Fix**

`src/sd.py`: Add an explicit `decode()` override to `CustomVAE`. For 2D VAEs (`latent_dim != 3`) it delegates to the parent as before. For 3D VAEs (the WanVAE family: Wan 2.1, Wan 2.2, Qwen-Image), it handles VRAM management itself and calls the existing `decode_tiled_3d()` directly, which already correctly uses `real_output_channels` and applies `process_output`. This makes the 3D decode path explicitly owned by `CustomVAE` rather than depending on the parent's internal behavior.

`nodes.py`: Add a belt-and-suspenders range guard after decode. If output is detected outside `[0, 1]` (i.e. `process_output` was somehow not applied), the correct normalization is applied. This is safe because a correctly decoded image is always in `[0, 1]` so the branch never fires on working paths. Also fixes an unconditional `pixel_shuffle` call that ran even when `upscale == 1`.

**Tested with**
- Qwen-Image
- Qwen-Image 2512
- Qwen-Image-Edit-2509
- Qwen-Image-Edit-2511
- Wan2.1
- Wan2.2

**Not tested yet**
- Qwen-Image-Layered

*Diagnosed and patched with AI assistance (Claude). Fix validated working on ComfyUI 0.17.0 (20260320).*

**Before**
![masslevel-cui-nodes-vae-utils-qwen-image-before_patch](https://github.com/user-attachments/assets/467b42da-4682-45d7-82a9-c47b528a9a98)

**After**
![masslevel-cui-nodes-vae-utils-qwen-image-after_patch](https://github.com/user-attachments/assets/b9ef3512-0f08-4de1-ba2e-9581a2ffaa3c)